### PR TITLE
StandardCopyOption.REPLACE_EXISTING옵션 제거

### DIFF
--- a/community/src/main/java/community/community/entity/Member.java
+++ b/community/src/main/java/community/community/entity/Member.java
@@ -2,17 +2,13 @@ package community.community.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.springframework.cache.annotation.Cacheable;
 
 @Entity
-@Table(name = "Member")
+@Table(name = "Member", indexes = @Index(name = "idx_email", columnList = "email"))
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Cacheable
-@org.hibernate.annotations.Cache(usage= CacheConcurrencyStrategy.READ_WRITE)
 public class Member extends BasicTimeEntity{
 
     @Id @GeneratedValue

--- a/community/src/main/java/community/community/service/postService/PostRegistrationServiceImp.java
+++ b/community/src/main/java/community/community/service/postService/PostRegistrationServiceImp.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 
 @Service
@@ -85,7 +84,7 @@ public class PostRegistrationServiceImp implements PostRegistrationService {
         //디렉토리가 없으면 생성
         Files.createDirectories(filePath.getParent());
 
-        Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(file.getInputStream(), filePath);
 
         postFileRepository.save(PostMapper.toEntity(fileName, filePathStr, post));
 


### PR DESCRIPTION
파일 덮어쓰기로 인한 데이터 손상의 문제를 예방하기 위해 
해당 옵션을 제거
