### PR TITLE
ë빈 생성 과정에서 무íë¬  무한 순회가 발생하여 수정

### DIFF
--- a/community/src/main/java/community/community/controller/frontController/Controller.java
+++ b/community/src/main/java/community/community/controller/frontController/Controller.java
@@ -31,4 +31,9 @@ public class Controller {
     private String writePost() {
         return "postWrite";
     }
+
+    @GetMapping("/posts/recent")
+    private String recentPost(){
+        return "recent";
+    }
 }

--- a/community/src/main/java/community/community/controller/memberController/MemberLoginController.java
+++ b/community/src/main/java/community/community/controller/memberController/MemberLoginController.java
@@ -4,7 +4,7 @@ import community.community.dto.MemberDTO.MemberLoginDTO;
 import community.community.dto.MemberDTO.MemberSuccessLoginDTO;
 import community.community.exception.customException.NotFoundMemberException;
 import community.community.service.memberService.MemberLoginService;
-import community.community.service.postService.PostPopularFindService;
+import community.community.service.postService.PostRecentFindServiceImp;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ import java.util.Map;
 public class MemberLoginController {
 
     private final MemberLoginService memberLoginService;
-    private final PostPopularFindService postPopularFindService;
+    private final PostRecentFindServiceImp postPopularFindService;
 
     @PostMapping("/memberLogin")
     public ResponseEntity<Map<String, Object>> memberLogin(@RequestBody MemberLoginDTO memberLoginDTO, HttpServletRequest request){

--- a/community/src/main/java/community/community/controller/myPageController/MyPageController.java
+++ b/community/src/main/java/community/community/controller/myPageController/MyPageController.java
@@ -3,7 +3,7 @@ package community.community.controller.myPageController;
 import community.community.dto.MemberDTO.MemberIdAndEmailDTO;
 import community.community.dto.commentDTO.CommentOfMemberDTO;
 import community.community.dto.postDTO.PostOfMemberDTO;
-import community.community.service.myPageService.MyPageService;
+import community.community.service.myPageService.MyPageServiceImp;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,7 +21,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class MyPageController {
 
-    private final MyPageService myPageService;
+    private final MyPageServiceImp myPageService;
 
     @GetMapping("/myPageInfoMember/{id}")
     public ResponseEntity<Map<String, Object>> myPagebyMember(@PathVariable("id") Long id){

--- a/community/src/main/java/community/community/controller/postController/PostFindController.java
+++ b/community/src/main/java/community/community/controller/postController/PostFindController.java
@@ -2,7 +2,9 @@ package community.community.controller.postController;
 
 import community.community.dto.postDTO.PostDetailDTO;
 import community.community.dto.postDTO.PostFindAllDTO;
+import community.community.dto.postDTO.PostFindDTO;
 import community.community.service.postService.PostFindService;
+import community.community.service.postService.PostRecentFindService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -22,7 +25,7 @@ import java.util.Map;
 public class PostFindController {
 
     private final PostFindService postFindService;
-
+    private final PostRecentFindService postRecentFindService;
 
     @GetMapping("/postFindAll")
     public ResponseEntity<Map<String, Object>> postFindAll(
@@ -59,11 +62,14 @@ public class PostFindController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/posts/recent")
-    public ResponseEntity<Map<String, Object>> postRecent(){
+    @GetMapping("api/posts/recent")
+    public ResponseEntity<Map<String, Object>> postRecent(HttpSession session){
         Map<String, Object> response = new HashMap<>();
+        String loginEmail = (String) session.getAttribute("loginEmail");
 
-
+        List<PostFindDTO> postFindDTOS = postRecentFindService.findRecentPost(loginEmail);
+        response.put("recentPosts", postFindDTOS);
         return ResponseEntity.ok(response);
     }
+
 }

--- a/community/src/main/java/community/community/repository/postRepository/PostRepository.java
+++ b/community/src/main/java/community/community/repository/postRepository/PostRepository.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -44,6 +45,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "FROM Post p JOIN p.member m WHERE p.isDeleted=false AND LOWER(p.title) LIKE LOWER(CONCAT('%',:title,'%')) ORDER BY p.createTime DESC")
     @QueryHints(@QueryHint(name = "org.hibernate.readOnly", value="true"))
     Page<PostFindDTO> findSearchTitle(Pageable pageable, String title);
+
+
+    //최근 조회한 게시물
+    @Query("SELECT new community.community.dto.postDTO.PostFindDTO(p.id, p.title, m.email)" +
+    "FROM Post p JOIN p.member m WHERE p.isDeleted=false AND p.id IN :postId")
+    @QueryHints(@QueryHint(name = "org.hibernate.readOnly", value="true"))
+    List<PostFindDTO> findRecentPosts(@Param("postId") List<Long> postId);
 
     //좋아요 카운트 1감소 update 쿼리
     @Modifying

--- a/community/src/main/java/community/community/service/myPageService/MyPageService.java
+++ b/community/src/main/java/community/community/service/myPageService/MyPageService.java
@@ -3,34 +3,16 @@ package community.community.service.myPageService;
 import community.community.dto.MemberDTO.MemberIdAndEmailDTO;
 import community.community.dto.commentDTO.CommentOfMemberDTO;
 import community.community.dto.postDTO.PostOfMemberDTO;
-import community.community.service.commentService.CommentFindService;
-import community.community.service.memberService.MemberFindService;
-import community.community.service.postService.PostFindService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class MyPageService {
-
-    private final MemberFindService memberFindService;
-    private final PostFindService postFindService;
-    private final CommentFindService commentFindService;
-
+public interface MyPageService {
     //회원 정보 불러오기
-    public MemberIdAndEmailDTO findMember(Long id) {
-        MemberIdAndEmailDTO memberIdAndEmailDTO = memberFindService.findMember(id);
-        return memberIdAndEmailDTO;
-    }
+    MemberIdAndEmailDTO findMember(Long id);
 
+    //id에 해당하는 게시글 조회
+    Page<PostOfMemberDTO> findPostByMemberId(Pageable pageable, Long id);
 
-    public Page<PostOfMemberDTO> findPostByMemberId(Pageable pageable, Long id) {
-        return postFindService.findPostAllByMemberId(pageable, id);
-    }
-
-    public Page<CommentOfMemberDTO> findCommentByMemberId(Pageable pageable, Long id) {
-        return commentFindService.findAllCommentByMemberId(pageable, id);
-    }
+    //id에 해당하는 댓글 조회
+    Page<CommentOfMemberDTO> findCommentByMemberId(Pageable pageable, Long id);
 }

--- a/community/src/main/java/community/community/service/myPageService/MyPageServiceImp.java
+++ b/community/src/main/java/community/community/service/myPageService/MyPageServiceImp.java
@@ -1,0 +1,39 @@
+package community.community.service.myPageService;
+
+import community.community.dto.MemberDTO.MemberIdAndEmailDTO;
+import community.community.dto.commentDTO.CommentOfMemberDTO;
+import community.community.dto.postDTO.PostOfMemberDTO;
+import community.community.service.commentService.CommentFindService;
+import community.community.service.memberService.MemberFindService;
+import community.community.service.postService.PostFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageServiceImp implements MyPageService{
+
+    private final MemberFindService memberFindService;
+    private final PostFindService postFindService;
+    private final CommentFindService commentFindService;
+
+    //회원 정보 불러오기
+    @Override
+    public MemberIdAndEmailDTO findMember(Long id) {
+        MemberIdAndEmailDTO memberIdAndEmailDTO = memberFindService.findMember(id);
+        return memberIdAndEmailDTO;
+    }
+
+
+    @Override
+    public Page<PostOfMemberDTO> findPostByMemberId(Pageable pageable, Long id) {
+        return postFindService.findPostAllByMemberId(pageable, id);
+    }
+
+    @Override
+    public Page<CommentOfMemberDTO> findCommentByMemberId(Pageable pageable, Long id) {
+        return commentFindService.findAllCommentByMemberId(pageable, id);
+    }
+}

--- a/community/src/main/java/community/community/service/postService/PostDataAccessService.java
+++ b/community/src/main/java/community/community/service/postService/PostDataAccessService.java
@@ -1,0 +1,9 @@
+package community.community.service.postService;
+
+import community.community.dto.postDTO.PostFindDTO;
+import java.util.List;
+
+public interface PostDataAccessService {
+    List<PostFindDTO> findRecentPostsByIds(List<Long> postIds);
+    void addRecentPostToUser(String loginEmail, Long postId, List<Long> currentPosts);
+}

--- a/community/src/main/java/community/community/service/postService/PostDataAccessServiceImp.java
+++ b/community/src/main/java/community/community/service/postService/PostDataAccessServiceImp.java
@@ -1,0 +1,51 @@
+package community.community.service.postService;
+
+import community.community.dto.postDTO.PostFindDTO;
+import community.community.exception.customException.DBAccessException;
+import community.community.repository.postRepository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostDataAccessServiceImp implements PostDataAccessService {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public List<PostFindDTO> findRecentPostsByIds(List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        try {
+            return postRepository.findRecentPosts(postIds);
+        } catch (DataAccessException e) {
+            throw new DBAccessException("데이터베이스 접근에 문제가 발생했습니다.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("알 수 없는 문제가 발생했습니다.", e);
+        }
+    }
+
+    @Override
+    public void addRecentPostToUser(String loginEmail, Long postId, List<Long> currentPosts) {
+        if (loginEmail == null || postId == null) {
+            return;
+        }
+
+        // 중복 객체 제거
+        currentPosts.remove(postId);
+        currentPosts.add(0, postId);
+
+        // 최대 10개 유지
+        if (currentPosts.size() > 10) {
+            currentPosts.remove(currentPosts.size() - 1);
+        }
+    }
+}

--- a/community/src/main/java/community/community/service/postService/PostFindService.java
+++ b/community/src/main/java/community/community/service/postService/PostFindService.java
@@ -2,11 +2,14 @@ package community.community.service.postService;
 
 import community.community.dto.postDTO.PostDetailDTO;
 import community.community.dto.postDTO.PostFindAllDTO;
+import community.community.dto.postDTO.PostFindDTO;
 import community.community.dto.postDTO.PostOfMemberDTO;
 import community.community.entity.Post;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface PostFindService {
 
@@ -19,4 +22,6 @@ public interface PostFindService {
 
     //단일 회원의 게시글 조회
     Page<PostOfMemberDTO> findPostAllByMemberId(Pageable pageable, Long id);
+
+    List<PostFindDTO> findRecentPost(List<Long> postId);
 }

--- a/community/src/main/java/community/community/service/postService/PostRecentFindService.java
+++ b/community/src/main/java/community/community/service/postService/PostRecentFindService.java
@@ -1,0 +1,18 @@
+package community.community.service.postService;
+
+import community.community.dto.postDTO.PostFindDTO;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.List;
+
+public interface PostRecentFindService {
+
+    //map에 최근 글 추가
+    void addRecentPosts(HttpSession session, Long postId);
+
+    //db에 저장 후 map의 특정 데이터를 삭제
+    void saveRecentPost(String loginEmail);
+
+    //최근 게시물 반환 기능
+    List<PostFindDTO> findRecentPost(String loginEmail);
+}

--- a/community/src/main/resources/templates/recent.html
+++ b/community/src/main/resources/templates/recent.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>최근 조회한 게시물</title>
+  <style>
+    /* 전체 스타일 */
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+        font-family: 'Malgun Gothic', '맑은 고딕', sans-serif;
+    }
+
+    body {
+        background-color: #f5f6f7;
+        color: #222;
+        line-height: 1.5;
+    }
+
+    /* 헤더 스타일 */
+    .header {
+        background-color: #03c75a;
+        padding: 15px 0;
+        text-align: center;
+    }
+
+    .header h1 {
+        color: white;
+        font-size: 24px;
+        font-weight: bold;
+    }
+
+    /* 컨테이너 스타일 */
+    .container {
+        max-width: 800px;
+        margin: 20px auto;
+        background-color: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        padding: 20px;
+    }
+
+    /* 타이틀 스타일 */
+    .title-area {
+        border-bottom: 1px solid #e5e5e5;
+        padding-bottom: 15px;
+        margin-bottom: 20px;
+    }
+
+    .title-area h2 {
+        font-size: 18px;
+        color: #03c75a;
+        font-weight: bold;
+    }
+
+    .title-area p {
+        font-size: 13px;
+        color: #666;
+        margin-top: 5px;
+    }
+
+    /* 게시물 목록 스타일 */
+    .post-list {
+        list-style: none;
+    }
+
+    .post-item {
+        padding: 15px 10px;
+        border-bottom: 1px solid #f0f0f0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        transition: background-color 0.2s;
+    }
+
+    .post-item:hover {
+        background-color: #f9f9f9;
+    }
+
+    .post-item:last-child {
+        border-bottom: none;
+    }
+
+    .post-title {
+        font-size: 14px;
+        color: #222;
+        font-weight: normal;
+        flex-grow: 1;
+        text-decoration: none;
+    }
+
+    .post-title:hover {
+        text-decoration: underline;
+        color: #03c75a;
+    }
+
+    .post-author {
+        font-size: 12px;
+        color: #999;
+        margin-left: 15px;
+    }
+
+    /* 빈 목록 스타일 */
+    .empty-list {
+        text-align: center;
+        padding: 50px 0;
+        color: #999;
+        font-size: 14px;
+    }
+
+    /* 푸터 스타일 */
+    .footer {
+        text-align: center;
+        margin-top: 20px;
+        font-size: 12px;
+        color: #999;
+    }
+
+    /* 반응형 스타일 */
+    @media (max-width: 768px) {
+        .container {
+            margin: 10px;
+            width: auto;
+        }
+    }
+  </style>
+</head>
+<body>
+<div class="header">
+  <h1>커뮤니티</h1>
+</div>
+
+<div class="container">
+  <div class="title-area">
+    <h2>최근 조회한 게시물</h2>
+    <p>최근에 확인한 게시물 목록입니다. (최대 10개)</p>
+  </div>
+
+  <ul class="post-list" id="recentPostsList">
+    <!-- JavaScript로 데이터 삽입 -->
+  </ul>
+
+  <div class="footer">
+    © 2025 커뮤니티 서비스
+  </div>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+      // API에서 최근 게시물 데이터 가져오기
+      fetch('/api/posts/recent')
+          .then(response => response.json())
+          .then(data => {
+              const postsList = document.getElementById('recentPostsList');
+
+              // 데이터가 없는 경우
+              if (!data.recentPosts || data.recentPosts.length === 0) {
+                  postsList.innerHTML = '<div class="empty-list">최근 조회한 게시물이 없습니다.</div>';
+                  return;
+              }
+
+              // 최대 10개까지만 표시
+              const posts = data.recentPosts.slice(0, 10);
+
+              // 게시물 목록 생성
+              posts.forEach(post => {
+                  const li = document.createElement('li');
+                  li.className = 'post-item';
+
+                  li.innerHTML = `
+                      <a href="/posts/${post.id}" class="post-title">${post.title}</a>
+                      <span class="post-author">${post.member.email}</span>
+                  `;
+
+                  postsList.appendChild(li);
+              });
+          })
+          .catch(error => {
+              console.error('데이터를 불러오는 중 오류가 발생했습니다:', error);
+              document.getElementById('recentPostsList').innerHTML =
+                  '<div class="empty-list">데이터를 불러오는 중 오류가 발생했습니다.</div>';
+          });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
클라이언트로 최근 게시물을 반환하는 기능을 추가

이 과정에서 빈 생성 시 무한 순회 문제가 발생 -> 클래스 재설계를 통해 오류 수정

++ 수정 필요
클라이언트로 반환했을 때, 클라이언트 측에서 최신 게시물의 순서가 고정이 되어있는 것을 확인
